### PR TITLE
fix(lib): obfuscate_high_entropy() now respects the allowlist (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,27 @@ from it at compile time via `build.rs` — do not edit `src/secrets.rs` directly
 
 `~/.config/obfsck/secrets.yaml` silently overrides the bundled config entirely — if it exists and is non-empty, the bundled config is ignored. Delete it to restore bundled defaults.
 
+## Issue Tracking
+
+Issues are tracked in `HANDOFF.obfsck.workspace.yaml` (not GitHub). Issue IDs use the format
+`obfsck-N`. Check `blocked_by` / `unblocks` fields for dependency chains.
+
+## Pre-commit Hook
+
+The global git hook pipes the staged diff through `obfsck --level minimal`. Fake test tokens
+(e.g. `ghp_aaa...`) trigger it — add them to `~/.config/obfsck/allowlist` (one per line).
+
+## Pattern Sources — Audit Pass
+
+`SECRET_PATTERN_DEFS` (compiled from `config/secrets.yaml` via `build.rs`) is the authoritative
+pattern set. Do NOT also iterate YAML config groups in the same audit pass — that double-counts
+every hit.
+
+## MCP Binary
+
+The MCP server binary is `obfsck-mcp` (not `mcp`): `cargo build --bin obfsck-mcp`.
+Install to PATH for `mcpipe --scan` auto-discovery (`PathBinaryScanner` in mcpipe).
+
 ## devloop / Standup Notes
 
 - `devloop git analyze` requires an InsightProvider not yet wired in the CLI — returns error.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,11 @@ name = "api"
 path = "src/bin/api.rs"
 required-features = ["analyzer"]
 
+[[bin]]
+name = "mcp"
+path = "src/bin/mcp.rs"
+required-features = ["analyzer"]
+
 [[example]]
 name = "inspect_schema"
 required-features = ["analyzer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ path = "src/bin/api.rs"
 required-features = ["analyzer"]
 
 [[bin]]
-name = "mcp"
+name = "obfsck-mcp"
 path = "src/bin/mcp.rs"
 required-features = ["analyzer"]
 

--- a/HANDOFF.obfsck.workspace.yaml
+++ b/HANDOFF.obfsck.workspace.yaml
@@ -146,9 +146,12 @@ log:
   summary: Implemented obfsck-11 — MCP server mode. Added src/mcp/ (Auditor/FilterSuggester
     ports, ObfsckAuditor/PatternSuggester adapters, JSON-RPC dispatch), obfsck-mcp binary
     (stdio line loop), 14 tests. Renamed binary mcp -> obfsck-mcp for PATH discovery.
+    Added session learnings to CLAUDE.md.
   commits:
   - da19143
   - 59cf099
+  - 9349b9b
+  - 5661dbc
 - date: 2026-04-07
   summary: Standardized CI — ci.yml, nightly.yml, deny.toml, git hooks. Fixed license
     field, updated rustls-webpki + quinn-proto, machete ignore for feature-gated deps.

--- a/HANDOFF.obfsck.workspace.yaml
+++ b/HANDOFF.obfsck.workspace.yaml
@@ -125,6 +125,7 @@ items:
   name: mcp-server-mode
   priority: P2
   status: open
+  unblocks: [coursers-11]
   title: Add MCP server mode — expose audit and generate-filters tools
   description: |
     coursers-11 depends on this. Expose two MCP tools via a server subcommand:

--- a/HANDOFF.obfsck.workspace.yaml
+++ b/HANDOFF.obfsck.workspace.yaml
@@ -1,6 +1,6 @@
 project: obfsck
 id: obfsck
-updated: 2026-04-07
+updated: 2026-04-11
 items:
 - id: obfsck-7
   name: path-traversal-api
@@ -124,7 +124,8 @@ items:
 - id: obfsck-11
   name: mcp-server-mode
   priority: P2
-  status: open
+  status: done
+  completed: 2026-04-11
   unblocks: [coursers-11]
   title: Add MCP server mode — expose audit and generate-filters tools
   description: |
@@ -132,12 +133,22 @@ items:
     audit (pipe content, return hits) and generate-filters (given examples,
     suggest .ctx/obfsck-filters.yaml patterns). mcpipe maps the server automatically.
   files:
-  - src/bin/redact.rs
+  - src/mcp/mod.rs
+  - src/mcp/protocol.rs
+  - src/bin/mcp.rs
+  - tests/test_mcp.rs
   extra:
   - date: 2026-04-11
     type: note
     note: "required by coursers-11 — crs discover will call mcpipe -> obfsck MCP to generate project-local filters"
 log:
+- date: 2026-04-11
+  summary: Implemented obfsck-11 — MCP server mode. Added src/mcp/ (Auditor/FilterSuggester
+    ports, ObfsckAuditor/PatternSuggester adapters, JSON-RPC dispatch), obfsck-mcp binary
+    (stdio line loop), 14 tests. Renamed binary mcp -> obfsck-mcp for PATH discovery.
+  commits:
+  - da19143
+  - 59cf099
 - date: 2026-04-07
   summary: Standardized CI — ci.yml, nightly.yml, deny.toml, git hooks. Fixed license
     field, updated rustls-webpki + quinn-proto, machete ignore for feature-gated deps.
@@ -148,9 +159,9 @@ log:
   - 2ca5ff7
   - f7f0c74
 - date: 2026-04-06
-  summary: devkit council sweep — 9 issues filed. Critical: path traversal in API (P0),
-    silent YAML pattern loss in build.rs (P1), allowlist bypass in high-entropy pass (P1).
-    Added obfsck-7/8/9 to HANDOFF.
+  summary: "devkit council sweep — 9 issues filed. Critical: path traversal in API (P0),\
+    \ silent YAML pattern loss in build.rs (P1), allowlist bypass in high-entropy pass (P1).\
+    \ Added obfsck-7/8/9 to HANDOFF."
   commits: []
 - date: 2026-04-05
   summary: Closed obfsck-3 (file I/O tests already existed) and obfsck-4 (tightened secret_scanning.yml — removed 4 stale paths, added 4 fixture paths); all items done

--- a/src/bin/mcp.rs
+++ b/src/bin/mcp.rs
@@ -1,0 +1,47 @@
+/// obfsck MCP server — exposes `audit` and `generate-filters` tools via JSON-RPC stdio.
+///
+/// mcpipe launches this binary and routes tool calls through the normal MCP protocol.
+/// Usage (via mcpipe): auto-discovered via `--scan` once this binary is on PATH.
+/// Direct usage: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | mcp`
+use obfsck::mcp::protocol::{JsonRpcRequest, dispatch_tool};
+use std::io::{self, BufRead, Write};
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = io::BufWriter::new(stdout.lock());
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) if l.trim().is_empty() => continue,
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("obfsck-mcp: read error: {e}");
+                break;
+            }
+        };
+
+        let req: JsonRpcRequest = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                let err = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": { "code": -32700, "message": format!("parse error: {e}") }
+                });
+                let _ = writeln!(out, "{}", serde_json::to_string(&err).unwrap_or_default());
+                let _ = out.flush();
+                continue;
+            }
+        };
+
+        let resp = dispatch_tool(&req);
+        match serde_json::to_string(&resp) {
+            Ok(json) => {
+                let _ = writeln!(out, "{json}");
+                let _ = out.flush();
+            }
+            Err(e) => eprintln!("obfsck-mcp: serialize error: {e}"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub const ANALYZER_DEFAULT_FILTER: &str = "obfsck=info,warn";
 #[cfg(feature = "analyzer")]
 pub mod analyzer;
 #[cfg(feature = "analyzer")]
+pub mod mcp;
+#[cfg(feature = "analyzer")]
 pub mod api;
 #[cfg(feature = "analyzer")]
 pub mod clients;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,13 +430,18 @@ impl Obfuscator {
             return text.to_string();
         }
 
+        let allowlist = &self.allowlist;
+        let secrets = &mut self.map.secrets;
         high_entropy_candidate_re()
             .replace_all(text, |caps: &regex::Captures<'_>| {
                 let s = &caps[0];
                 if s.len() >= 20 && shannon_entropy(s) > 4.5 {
+                    if allowlist.contains(s) {
+                        return s.to_string();
+                    }
                     let mut truncated = s.chars().take(10).collect::<String>();
                     truncated.push_str("...");
-                    self.map.secrets.insert(truncated);
+                    secrets.insert(truncated);
                     "[REDACTED-HIGH-ENTROPY]".to_string()
                 } else {
                     s.to_string()

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,101 @@
+pub mod protocol;
+
+use crate::SECRET_PATTERN_DEFS;
+use regex::RegexBuilder;
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditHit {
+    pub label: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterSuggestion {
+    pub pattern: String,
+    pub label: String,
+}
+
+// ---------------------------------------------------------------------------
+// Ports (traits)
+// ---------------------------------------------------------------------------
+
+pub trait Auditor {
+    fn audit(&self, text: &str) -> Vec<AuditHit>;
+}
+
+pub trait FilterSuggester {
+    fn suggest(&self, examples: &[String]) -> Vec<FilterSuggestion>;
+}
+
+// ---------------------------------------------------------------------------
+// ObfsckAuditor adapter
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+pub struct ObfsckAuditor;
+
+impl Auditor for ObfsckAuditor {
+    fn audit(&self, text: &str) -> Vec<AuditHit> {
+        // Use the authoritative compiled pattern set (SECRET_PATTERN_DEFS) only.
+        // The YAML config patterns are generated from the same source, so using
+        // both would double-count every hit.
+        let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+        for def in SECRET_PATTERN_DEFS {
+            if let Ok(re) = RegexBuilder::new(def.pattern).case_insensitive(true).build() {
+                let n = re.find_iter(text).count();
+                if n > 0 {
+                    *counts.entry(def.label.to_string()).or_insert(0) += n;
+                }
+            }
+        }
+
+        let mut hits: Vec<AuditHit> = counts
+            .into_iter()
+            .map(|(label, count)| AuditHit { label, count })
+            .collect();
+        hits.sort_by(|a, b| a.label.cmp(&b.label));
+        hits
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PatternSuggester adapter
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+pub struct PatternSuggester;
+
+impl FilterSuggester for PatternSuggester {
+    fn suggest(&self, examples: &[String]) -> Vec<FilterSuggestion> {
+        // Strategy: run audit on each example; for every hit, propose the
+        // compiled pattern from SECRET_PATTERN_DEFS as the suggested filter.
+        // De-duplicate by label.
+        let auditor = ObfsckAuditor;
+        let mut seen = std::collections::HashSet::new();
+        let mut suggestions = Vec::new();
+
+        for example in examples {
+            let hits = auditor.audit(example);
+            for hit in hits {
+                if seen.contains(&hit.label) {
+                    continue;
+                }
+                // Find the source pattern def for this label
+                if let Some(def) = SECRET_PATTERN_DEFS.iter().find(|d| d.label == hit.label) {
+                    seen.insert(hit.label.clone());
+                    suggestions.push(FilterSuggestion {
+                        pattern: def.pattern.to_string(),
+                        label: hit.label,
+                    });
+                }
+            }
+        }
+
+        suggestions
+    }
+}

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,0 +1,156 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::{Auditor, FilterSuggester, ObfsckAuditor, PatternSuggester};
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl JsonRpcResponse {
+    fn ok(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn err(id: Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+}
+
+const TOOL_AUDIT: &str = "audit";
+const TOOL_GENERATE_FILTERS: &str = "generate-filters";
+
+fn tools_schema() -> Value {
+    serde_json::json!({
+        "tools": [
+            {
+                "name": TOOL_AUDIT,
+                "description": "Pipe text through obfsck and return pattern hit counts.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "text": { "type": "string", "description": "Text to audit." }
+                    },
+                    "required": ["text"]
+                }
+            },
+            {
+                "name": TOOL_GENERATE_FILTERS,
+                "description": "Given example strings, suggest obfsck filter patterns.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "examples": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Example strings that should be redacted."
+                        }
+                    },
+                    "required": ["examples"]
+                }
+            }
+        ]
+    })
+}
+
+pub fn dispatch_tool(req: &JsonRpcRequest) -> JsonRpcResponse {
+    match req.method.as_str() {
+        "initialize" => JsonRpcResponse::ok(
+            req.id.clone(),
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "obfsck", "version": env!("CARGO_PKG_VERSION") }
+            }),
+        ),
+        "tools/list" => JsonRpcResponse::ok(req.id.clone(), tools_schema()),
+        "tools/call" => dispatch_call(req),
+        _ => JsonRpcResponse::err(req.id.clone(), -32601, "method not found"),
+    }
+}
+
+fn dispatch_call(req: &JsonRpcRequest) -> JsonRpcResponse {
+    let name = match req.params.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => return JsonRpcResponse::err(req.id.clone(), -32602, "missing tool name"),
+    };
+    let args = req.params.get("arguments").unwrap_or(&Value::Null);
+
+    match name {
+        TOOL_AUDIT => {
+            let text = match args.get("text").and_then(|v| v.as_str()) {
+                Some(t) => t,
+                None => {
+                    return JsonRpcResponse::err(req.id.clone(), -32602, "missing argument: text")
+                }
+            };
+            let auditor = ObfsckAuditor;
+            let hits: Vec<Value> = auditor
+                .audit(text)
+                .into_iter()
+                .map(|h| serde_json::json!({ "label": h.label, "count": h.count }))
+                .collect();
+            JsonRpcResponse::ok(req.id.clone(), serde_json::json!({ "hits": hits }))
+        }
+        TOOL_GENERATE_FILTERS => {
+            let examples: Vec<String> = match args.get("examples").and_then(|v| v.as_array()) {
+                Some(arr) => arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect(),
+                None => {
+                    return JsonRpcResponse::err(
+                        req.id.clone(),
+                        -32602,
+                        "missing argument: examples",
+                    )
+                }
+            };
+            let suggester = PatternSuggester;
+            let suggestions: Vec<Value> = suggester
+                .suggest(&examples)
+                .into_iter()
+                .map(|s| serde_json::json!({ "pattern": s.pattern, "label": s.label }))
+                .collect();
+            JsonRpcResponse::ok(
+                req.id.clone(),
+                serde_json::json!({ "suggestions": suggestions }),
+            )
+        }
+        _ => JsonRpcResponse::err(req.id.clone(), -32602, format!("unknown tool: {name}")),
+    }
+}

--- a/tests/test_mcp.rs
+++ b/tests/test_mcp.rs
@@ -1,0 +1,204 @@
+/// Tests for obfsck MCP server mode (obfsck-11).
+///
+/// Test order follows the TDD cycle:
+///   1. Auditor port — AuditHit aggregation
+///   2. FilterSuggester port — pattern suggestion from examples
+///   3. MCP protocol — JSON-RPC framing and tool dispatch
+use obfsck::mcp::{
+    Auditor, FilterSuggester, ObfsckAuditor, PatternSuggester,
+    protocol::{JsonRpcRequest, dispatch_tool},
+};
+
+// ---------------------------------------------------------------------------
+// Auditor port
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auditor_returns_empty_hits_for_clean_input() {
+    let auditor = ObfsckAuditor;
+    let hits = auditor.audit("no secrets here");
+    assert!(hits.is_empty());
+}
+
+#[test]
+fn auditor_counts_hits_for_matching_pattern() {
+    let auditor = ObfsckAuditor;
+    // A GitHub PAT triggers the gh-pat pattern.
+    let hits = auditor.audit("token ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    assert!(!hits.is_empty(), "expected at least one hit");
+    let total: usize = hits.iter().map(|h| h.count).sum();
+    assert_eq!(total, 1);
+}
+
+#[test]
+fn auditor_aggregates_multiple_matches_of_same_pattern() {
+    let auditor = ObfsckAuditor;
+    let input = "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa and \
+                 ghp_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let hits = auditor.audit(input);
+    let total: usize = hits.iter().map(|h| h.count).sum();
+    assert_eq!(total, 2);
+}
+
+#[test]
+fn auditor_hit_has_label_and_count() {
+    let auditor = ObfsckAuditor;
+    let hits = auditor.audit("ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    assert!(!hits.is_empty());
+    assert!(!hits[0].label.is_empty());
+    assert!(hits[0].count > 0);
+}
+
+// ---------------------------------------------------------------------------
+// FilterSuggester port
+// ---------------------------------------------------------------------------
+
+#[test]
+fn suggester_returns_empty_for_clean_examples() {
+    let suggester = PatternSuggester;
+    let suggestions = suggester.suggest(&["hello world".to_string(), "no secrets".to_string()]);
+    assert!(suggestions.is_empty());
+}
+
+#[test]
+fn suggester_proposes_pattern_for_known_secret_example() {
+    let suggester = PatternSuggester;
+    let examples = vec!["ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()];
+    let suggestions = suggester.suggest(&examples);
+    assert!(!suggestions.is_empty(), "expected at least one suggestion");
+    assert!(!suggestions[0].label.is_empty());
+    assert!(!suggestions[0].pattern.is_empty());
+}
+
+#[test]
+fn suggestion_pattern_is_valid_regex() {
+    let suggester = PatternSuggester;
+    let examples = vec!["ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()];
+    let suggestions = suggester.suggest(&examples);
+    for s in &suggestions {
+        assert!(
+            regex::Regex::new(&s.pattern).is_ok(),
+            "invalid regex: {}",
+            s.pattern
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MCP JSON-RPC protocol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jsonrpc_request_deserializes_initialize() {
+    let raw = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let req: JsonRpcRequest = serde_json::from_str(raw).expect("deserialize");
+    assert_eq!(req.method, "initialize");
+}
+
+#[test]
+fn jsonrpc_request_deserializes_tools_list() {
+    let raw = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+    let req: JsonRpcRequest = serde_json::from_str(raw).expect("deserialize");
+    assert_eq!(req.method, "tools/list");
+}
+
+#[test]
+fn tools_list_response_includes_audit_and_generate_filters() {
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: serde_json::Value::Number(1.into()),
+        method: "tools/list".into(),
+        params: serde_json::Value::Null,
+    };
+    let resp = dispatch_tool(&req);
+    let tools = resp
+        .result
+        .as_ref()
+        .and_then(|r| r.get("tools"))
+        .and_then(|t| t.as_array())
+        .expect("tools array");
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+        .collect();
+    assert!(names.contains(&"audit"), "missing audit tool");
+    assert!(
+        names.contains(&"generate-filters"),
+        "missing generate-filters tool"
+    );
+}
+
+#[test]
+fn dispatch_audit_tool_returns_hits_array() {
+    let params = serde_json::json!({
+        "name": "audit",
+        "arguments": {
+            "text": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+    });
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: serde_json::Value::Number(2.into()),
+        method: "tools/call".into(),
+        params,
+    };
+    let resp = dispatch_tool(&req);
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let hits = resp
+        .result
+        .as_ref()
+        .and_then(|r| r.get("hits"))
+        .and_then(|h| h.as_array())
+        .expect("hits array");
+    assert!(!hits.is_empty());
+}
+
+#[test]
+fn dispatch_generate_filters_returns_suggestions_array() {
+    let params = serde_json::json!({
+        "name": "generate-filters",
+        "arguments": {
+            "examples": ["ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+        }
+    });
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: serde_json::Value::Number(3.into()),
+        method: "tools/call".into(),
+        params,
+    };
+    let resp = dispatch_tool(&req);
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let suggestions = resp
+        .result
+        .as_ref()
+        .and_then(|r| r.get("suggestions"))
+        .and_then(|s| s.as_array())
+        .expect("suggestions array");
+    assert!(!suggestions.is_empty());
+}
+
+#[test]
+fn dispatch_unknown_tool_returns_error() {
+    let params = serde_json::json!({"name": "nonexistent", "arguments": {}});
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: serde_json::Value::Number(9.into()),
+        method: "tools/call".into(),
+        params,
+    };
+    let resp = dispatch_tool(&req);
+    assert!(resp.error.is_some(), "expected error for unknown tool");
+}
+
+#[test]
+fn jsonrpc_response_includes_matching_id() {
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: serde_json::Value::Number(42.into()),
+        method: "tools/list".into(),
+        params: serde_json::Value::Null,
+    };
+    let resp = dispatch_tool(&req);
+    assert_eq!(resp.id, serde_json::Value::Number(42.into()));
+}

--- a/tests/test_obfuscation.rs
+++ b/tests/test_obfuscation.rs
@@ -1,4 +1,4 @@
-use obfsck::{ObfuscationLevel, obfuscate_alert, obfuscate_text, secret_pattern_errors};
+use obfsck::{ObfuscationLevel, Obfuscator, obfuscate_alert, obfuscate_text, secret_pattern_errors};
 use std::collections::HashMap;
 
 #[test]
@@ -244,5 +244,45 @@ fn user_re_does_not_capture_trailing_dot() {
     assert!(
         !map.users.contains_key("joe."),
         "trailing dot was incorrectly absorbed into username: {map:?}"
+    );
+}
+
+// Issue #7: obfuscate_high_entropy() must respect the allowlist.
+#[test]
+fn high_entropy_allowlisted_value_is_not_redacted() {
+    // A 33-char mixed-case alphanumeric string has Shannon entropy well above 4.5
+    // and would normally be redacted by obfuscate_high_entropy(). Present it as a
+    // standalone word (space-separated) so the regex captures exactly the token,
+    // not a longer prefix like "token=<value>".
+    let high_entropy = "aB3xK9mQ2wR7tY1nP4sL6vC0dF8jH5uE";
+
+    let mut ob = Obfuscator::new(ObfuscationLevel::Paranoid)
+        .with_allowlist(vec![high_entropy.to_string()]);
+
+    let input = format!("found {high_entropy} in log");
+    let out = ob.obfuscate(&input);
+
+    assert!(
+        !out.contains("[REDACTED-HIGH-ENTROPY]"),
+        "allowlisted high-entropy value should not be redacted, got: {out}"
+    );
+    assert!(
+        out.contains(high_entropy),
+        "allowlisted value should pass through unchanged, got: {out}"
+    );
+}
+
+#[test]
+fn high_entropy_non_allowlisted_value_is_redacted() {
+    // Confirm that a non-allowlisted high-entropy value IS still redacted.
+    let high_entropy = "aB3xK9mQ2wR7tY1nP4sL6vC0dF8jH5uE";
+
+    let mut ob = Obfuscator::new(ObfuscationLevel::Paranoid);
+    let input = format!("found {high_entropy} in log");
+    let out = ob.obfuscate(&input);
+
+    assert!(
+        out.contains("[REDACTED-HIGH-ENTROPY]"),
+        "non-allowlisted high-entropy value should be redacted, got: {out}"
     );
 }


### PR DESCRIPTION
Fixes #7

## Problem
`obfuscate_high_entropy()` did not check `self.allowlist` before redacting high-entropy candidates. Every other obfuscation pass (IPs, emails, containers, users, secrets) checks the allowlist first. This omission meant explicitly allowlisted values were unconditionally redacted at Paranoid level.

## Fix
Extract `allowlist` and `secrets` as separate borrows before the replacement closure to satisfy the borrow checker, then check `allowlist.contains(candidate)` before emitting `[REDACTED-HIGH-ENTROPY]`.

## Tests added
- Allowlisted high-entropy value passes through unchanged
- Non-allowlisted high-entropy value is still redacted