### PR TITLE
fix(lib): obfuscate_paths() now records mappings in ObfuscationMap.paths (#4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,7 @@ impl Obfuscator {
             return text.to_string();
         }
 
+        let paths = &mut self.map.paths;
         path_re()
             .replace_all(text, |caps: &regex::Captures<'_>| {
                 let path = &caps[0];
@@ -430,7 +431,10 @@ impl Obfuscator {
                     return path.to_string();
                 }
 
-                obfuscate_path_value(path)
+                paths
+                    .entry(path.to_string())
+                    .or_insert_with(|| obfuscate_path_value(path))
+                    .clone()
             })
             .into_owned()
     }

--- a/tests/test_obfuscation.rs
+++ b/tests/test_obfuscation.rs
@@ -340,3 +340,43 @@ fn ipv6_public_address_tagged_ip_external() {
         "IPv6 public address must not be IP-INTERNAL, got: {out}"
     );
 }
+
+// Issue #4: obfuscate_paths() must record path→token mappings in ObfuscationMap.paths.
+#[test]
+fn obfuscate_paths_populates_map() {
+    // /etc/passwd is a well-known sensitive path — it won't be redacted by
+    // is_sensitive_path(). Use a non-sensitive path that path_re() will match.
+    let input = "opened /home/alice/secret.conf for reading";
+    let (out, map) = obfuscate_text(input, ObfuscationLevel::Paranoid);
+
+    // The path should have been rewritten.
+    assert!(
+        !out.contains("/home/alice/secret.conf"),
+        "path should be obfuscated in output, got: {out}"
+    );
+    // And recorded in the mapping.
+    assert!(
+        !map.paths.is_empty(),
+        "ObfuscationMap.paths should be populated after path obfuscation, got empty map.\nout={out}"
+    );
+}
+
+#[test]
+fn obfuscate_paths_same_path_gets_same_token() {
+    // The same path appearing twice must receive the same token (idempotent mapping).
+    let input = "read /tmp/data.txt and write /tmp/data.txt";
+    let (out, map) = obfuscate_text(input, ObfuscationLevel::Paranoid);
+
+    assert_eq!(
+        map.paths.len(),
+        1,
+        "one unique path should produce exactly one map entry, got: {map:?}\nout={out}"
+    );
+    // The two occurrences in the output should be identical tokens.
+    let token = map.paths.values().next().unwrap();
+    let count = out.matches(token.as_str()).count();
+    assert_eq!(
+        count, 2,
+        "the same token should appear twice in output, got: {out}"
+    );
+}


### PR DESCRIPTION
Fixes #4

## Problem
`obfuscate_paths()` computed obfuscated tokens via `obfuscate_path_value()` but never inserted the original→token mapping into `self.map.paths`. `ObfuscationMap.paths` was always empty, making it impossible for callers to reverse or audit path substitutions.

## Fix
Use `entry().or_insert_with()` to both store the mapping and return the token. As a side effect, the same path now consistently receives the same token across multiple occurrences in one pass.

## Tests added
- `obfuscate_paths_populates_map` — paths map is non-empty after obfuscation
- `obfuscate_paths_same_path_gets_same_token` — duplicate path → identical token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced path obfuscation with caching for improved performance and consistent, deterministic output.

* **Tests**
  * Added test coverage validating path obfuscation consistency and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->